### PR TITLE
Enable warnings-as-error when building tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,8 +92,8 @@ endfunction()
 # enable a large amount of extra warnings, regardless of build mode
 if (MSVC) # MSVC supports different warning options to GCC/Clang
     enable_cxx_compiler_flag_if_supported("/W3") # MSVC Warning level 3, 4 is too pedantic
-    # if in debug mode, enable converting all warnings to errors too
-    if (WONDERCARD_BUILD_DEBUG)
+    # if tests are enabled, enable converting all warnings to errors too
+    if (ENABLE_TESTS)
         enable_cxx_compiler_flag_if_supported("/WX")
     endif()
 else() # GCC/Clang warning option
@@ -112,8 +112,8 @@ else() # GCC/Clang warning option
     enable_cxx_compiler_flag_if_supported("-Wsign-conversion")
     # enable warnings about mistakes in Doxygen documentation
     enable_cxx_compiler_flag_if_supported("-Wdocumentation")
-    # if in debug mode, enable converting all warnings to errors too
-    if (WONDERCARD_BUILD_DEBUG)
+    # if tests are enabled, enable converting all warnings to errors too
+    if (ENABLE_TESTS)
         enable_cxx_compiler_flag_if_supported("-Werror")
         # exclude the following kinds of warnings from being converted into errors
         # unknown-pragma is useful to have as a warning but not as an error, if you have


### PR DESCRIPTION
This will stop warning-errors creeping in to the code unnoticed